### PR TITLE
Fix `findRedexes` and commute handedness, rename `L/R` to `A1/A2`

### DIFF
--- a/src/SIC/INet/Examples.hs
+++ b/src/SIC/INet/Examples.hs
@@ -5,47 +5,47 @@ import           SIC.Type
 
 trivialCommute1 ∷ Net
 trivialCommute1 = makeNet
-  [ CONS (Ptr 1 P) (Ptr 2 L) (Ptr 3 L)
-  , DUPL (Ptr 0 P) (Ptr 4 L) (Ptr 5 L)
-  , FREE (Ptr 0 L)
-  , FREE (Ptr 0 R)
-  , FREE (Ptr 1 L)
-  , FREE (Ptr 1 R)
+  [ CONS (Ptr 1 P) (Ptr 2 A1) (Ptr 3 A1)
+  , DUPL (Ptr 0 P) (Ptr 4 A1) (Ptr 5 A1)
+  , FREE (Ptr 0 A1)
+  , FREE (Ptr 0 A2)
+  , FREE (Ptr 1 A1)
+  , FREE (Ptr 1 A2)
   ]
 
 trivialCommute2 ∷ Net
 trivialCommute2 = makeNet
-  [ CONS (Ptr 0 P) (Ptr 1 L) (Ptr 2 L)
-  , FREE (Ptr 0 L)
-  , FREE (Ptr 0 R)
+  [ CONS (Ptr 0 P) (Ptr 1 A1) (Ptr 2 A1)
+  , FREE (Ptr 0 A1)
+  , FREE (Ptr 0 A2)
   ]
 
 trivialCommute3 ∷ Net
 trivialCommute3 = makeNet
-  [ DUPL (Ptr 0 P) (Ptr 1 L) (Ptr 2 L)
-  , FREE (Ptr 0 L)
-  , FREE (Ptr 0 R)
+  [ DUPL (Ptr 0 P) (Ptr 1 A1) (Ptr 2 A1)
+  , FREE (Ptr 0 A1)
+  , FREE (Ptr 0 A2)
   ]
 
 trivialAnnihilate1 ∷ Net
 trivialAnnihilate1 = makeNet
-  [ CONS (Ptr 1 P) (Ptr 2 L) (Ptr 3 L)
-  , CONS (Ptr 0 P) (Ptr 4 L) (Ptr 5 L)
-  , FREE (Ptr 0 L)
-  , FREE (Ptr 0 R)
-  , FREE (Ptr 1 L)
-  , FREE (Ptr 1 R)
+  [ CONS (Ptr 1 P) (Ptr 2 A1) (Ptr 3 A1)
+  , CONS (Ptr 0 P) (Ptr 4 A1) (Ptr 5 A1)
+  , FREE (Ptr 0 A1)
+  , FREE (Ptr 0 A2)
+  , FREE (Ptr 1 A1)
+  , FREE (Ptr 1 A2)
   ]
 
 
 trivialAnnihilate2 ∷ Net
 trivialAnnihilate2 = makeNet
-  [ CONS (Ptr 1 P) (Ptr 2 L) (Ptr 3 L)
-  , CONS (Ptr 0 P) (Ptr 4 L) (Ptr 5 L)
-  , FREE (Ptr 0 L)
-  , FREE (Ptr 0 R)
-  , FREE (Ptr 1 L)
-  , FREE (Ptr 1 R)
+  [ CONS (Ptr 1 P) (Ptr 2 A1) (Ptr 3 A1)
+  , CONS (Ptr 0 P) (Ptr 4 A1) (Ptr 5 A1)
+  , FREE (Ptr 0 A1)
+  , FREE (Ptr 0 A2)
+  , FREE (Ptr 1 A1)
+  , FREE (Ptr 1 A2)
   ]
 
 --trivialAnnihilate3 ∷ Net

--- a/src/SIC/Type.hs
+++ b/src/SIC/Type.hs
@@ -15,17 +15,17 @@ data Node
   | FREE Port            -- 1 slot: Left
   deriving (Show, Eq)
 
-data Slot = P | L | R
+data Slot = P | A1 | A2
   deriving (Show, Eq)
 
 slot ∷ Slot → Node → Port
-slot s (CONS p l r) = case s of P -> p; L -> l; R -> r;
-slot s (DUPL p l r) = case s of P -> p; L -> l; R -> r;
+slot s (CONS p l r) = case s of P -> p; A1 -> l; A2 -> r;
+slot s (DUPL p l r) = case s of P -> p; A1 -> l; A2 -> r;
 slot _ (FREE p)     = p
 
 setSlot ∷ Slot → Port → Node → Node
-setSlot s q (CONS p l r) = case s of P -> CONS q l r; L -> CONS p q r; R -> CONS p l q;
-setSlot s q (DUPL p l r) = case s of P -> DUPL q l r; L -> DUPL p q r; R -> DUPL p l q;
+setSlot s q (CONS p l r) = case s of P -> CONS q l r; A1 -> CONS p q r; A2 -> CONS p l q;
+setSlot s q (DUPL p l r) = case s of P -> DUPL q l r; A1 -> DUPL p q r; A2 -> DUPL p l q;
 setSlot _ q (FREE _) = FREE q
 
 data Kind = Cons | Dupl | Free deriving (Eq, Show)
@@ -36,9 +36,9 @@ kind (DUPL _ _ _) = Dupl
 kind (FREE _)     = Free
 
 defaultNode ∷ Int → Kind → Node
-defaultNode n Cons = CONS (Ptr n P) (Ptr n L) (Ptr n R)
-defaultNode n Dupl = DUPL (Ptr n P) (Ptr n L) (Ptr n R)
-defaultNode n Free = FREE (Ptr n L)
+defaultNode n Cons = CONS (Ptr n P) (Ptr n A1) (Ptr n A2)
+defaultNode n Dupl = DUPL (Ptr n P) (Ptr n A1) (Ptr n A2)
+defaultNode n Free = FREE (Ptr n A1)
 
 
 data Port = Ptr { toNode :: Int, toSlot :: Slot }


### PR DESCRIPTION
So one remaining issue is that `trivialCommute2` etc. leaves self-FREE nodes. Solution is to track down where self-Free's can be generated and add them to netRedexes.

```
Pre-reduction:
Net {netNodes = fromList 
 [ (0,CONS (Ptr {toNode = 0, toSlot = P}) (Ptr {toNode = 1, toSlot = A1}) (Ptr {toNode = 2, toSlot = A1}))
 , (1,FREE (Ptr {toNode = 0, toSlot = A1})),
 , (2,FREE (Ptr {toNode = 0, toSlot = A2}))
 ], netRedex = [(0,0) ]}
Reduced in 1 steps.
Post-reduction:
Net {netNodes = fromList
  [ (1,FREE (Ptr {toNode = 1, toSlot = A1}))
  , (2,FREE (Ptr {toNode = 2, toSlot = A1}))
], netRedex = []}

```

Can't think of any reason to keep these Free nodes around